### PR TITLE
Handle UI messages promptly in windowing loop

### DIFF
--- a/crates/umbr-ui/src/win.rs
+++ b/crates/umbr-ui/src/win.rs
@@ -15,11 +15,11 @@ use smithay_client_toolkit::{
     },
 };
 use std::{
-    sync::mpsc::{Receiver, Sender},
-    thread,
+    sync::mpsc::{Receiver, RecvTimeoutError, Sender},
+    time::Duration,
 };
 use wayland_client::{
-    Dispatch, Proxy, QueueHandle, delegate_noop,
+    Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
     globals::registry_queue_init,
     protocol::{
         wl_buffer::{self, WlBuffer},
@@ -91,55 +91,47 @@ pub fn windowing_thread(
 
     event_queue.roundtrip(&mut state)?;
 
-    while state.running {
-        event_queue.blocking_dispatch(&mut state).unwrap();
+    let fallback_size = (width as i32, height as i32);
+
+    'event_loop: while state.running {
+        event_queue.dispatch_pending(&mut state)?;
+        event_queue.flush()?;
+
+        if !state.running {
+            break 'event_loop;
+        }
 
         while let Ok(message) = receiver.try_recv() {
-            match message {
-                UiMessage::Render {
-                    width,
-                    height,
-                    stride,
-                    pixels,
-                } => {
-                    dbg!("Entrou aqui");
-                    state.render(
-                        &pixels,
-                        width as u32,
-                        height as u32,
-                    );
+            state.handle_ui_message(message, &mut event_queue, fallback_size)?;
+
+            if !state.running {
+                break 'event_loop;
+            }
+        }
+
+        if !state.running {
+            break 'event_loop;
+        }
+
+        match receiver.recv_timeout(Duration::from_millis(16)) {
+            Ok(message) => {
+                state.handle_ui_message(message, &mut event_queue, fallback_size)?;
+
+                if !state.running {
+                    break 'event_loop;
                 }
 
-                //  render(
-                //     &state.shm_state,
-                //     &state.wl_surface,
-                //     width.try_into().unwrap(),
-                //     height.try_into().unwrap(),
-                //     stride.try_into().unwrap(),
-                //     &pixels,
-                // ),
-                UiMessage::UnlockWithPassword { password } => {
-                    dbg!(&password);
-                    state.session_lock.unlock_and_destroy();
+                continue 'event_loop;
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                event_queue.blocking_dispatch(&mut state)?;
 
-                    state.wl_surface.attach(None, 0, 0);
-                    state
-                        .wl_surface
-                        .damage_buffer(0, 0, width as i32, height as i32);
-                    state.wl_surface.commit();
-
-                    event_queue.roundtrip(&mut state).unwrap();
-
-                    event_queue.dispatch_pending(&mut state).unwrap();
-                    event_queue.flush().unwrap();
-                    // state.
-                    state
-                        .render_thread_sender
-                        .send(WindowingMessage::Quit)
-                        .unwrap();
-                    state.running = false;
-                    state.locked = false;
+                if !state.running {
+                    break 'event_loop;
                 }
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                break 'event_loop;
             }
         }
     }
@@ -231,8 +223,8 @@ impl AppData {
 
         {
             for y in 0..height as usize {
-                let src_line =
-                    &pixels[(y * src_stride as usize)..(y * src_stride as usize + (width as usize * bpp))];
+                let src_line = &pixels
+                    [(y * src_stride as usize)..(y * src_stride as usize + (width as usize * bpp))];
                 let dst_line = &mut canvas
                     [(y * dst_stride as usize)..(y * dst_stride as usize + (width as usize * bpp))];
 
@@ -266,6 +258,59 @@ impl AppData {
         self.wl_surface
             .damage_buffer(0, 0, width as i32, height as i32);
         self.wl_surface.commit();
+    }
+
+    fn handle_ui_message(
+        &mut self,
+        message: UiMessage,
+        event_queue: &mut EventQueue<Self>,
+        fallback_size: (i32, i32),
+    ) -> Result<()> {
+        match message {
+            UiMessage::Render {
+                width,
+                height,
+                stride: _,
+                pixels,
+            } => {
+                dbg!("Entrou aqui");
+                self.render(&pixels, width as u32, height as u32);
+                event_queue.flush()?;
+            }
+            UiMessage::UnlockWithPassword { password } => {
+                dbg!(&password);
+                self.session_lock.unlock_and_destroy();
+
+                self.wl_surface.attach(None, 0, 0);
+
+                let (fallback_width, fallback_height) = fallback_size;
+                let damage_width = if self.width > 0 {
+                    self.width as i32
+                } else {
+                    fallback_width
+                };
+                let damage_height = if self.height > 0 {
+                    self.height as i32
+                } else {
+                    fallback_height
+                };
+
+                self.wl_surface
+                    .damage_buffer(0, 0, damage_width, damage_height);
+                self.wl_surface.commit();
+
+                event_queue.roundtrip(self)?;
+                event_queue.dispatch_pending(self)?;
+                event_queue.flush()?;
+                self.render_thread_sender
+                    .send(WindowingMessage::Quit)
+                    .unwrap();
+                self.running = false;
+                self.locked = false;
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/umbr-ui/src/win.rs
+++ b/crates/umbr-ui/src/win.rs
@@ -5,13 +5,14 @@ use smithay_client_toolkit::{
     registry::{ProvidesRegistryState, RegistryState},
     registry_handlers,
     seat::{
-        Capability, SeatHandler, SeatState,
         keyboard::{KeyEvent, KeyboardHandler, Keysym, Modifiers},
         pointer::{PointerEvent, PointerEventKind, PointerHandler},
+        Capability, SeatHandler, SeatState,
     },
     shm::{
-        self, Shm, ShmHandler,
+        self,
         slot::{Buffer, SlotPool},
+        Shm, ShmHandler,
     },
 };
 use std::{
@@ -19,7 +20,7 @@ use std::{
     time::Duration,
 };
 use wayland_client::{
-    Dispatch, EventQueue, Proxy, QueueHandle, delegate_noop,
+    delegate_noop,
     globals::registry_queue_init,
     protocol::{
         wl_buffer::{self, WlBuffer},
@@ -32,6 +33,7 @@ use wayland_client::{
         wl_surface::{self, WlSurface},
         wl_touch,
     },
+    Dispatch, DispatchError, EventQueue, Proxy, QueueHandle,
 };
 use wayland_protocols::ext::session_lock::v1::client::{
     ext_session_lock_manager_v1::{self, ExtSessionLockManagerV1},
@@ -68,9 +70,10 @@ pub fn windowing_thread(
     let shm_state = Shm::bind(&globals, &qh).expect("wl_shm not available");
     let wl_surface = compositor.create_surface(&qh, ());
     let output: wl_output::WlOutput = globals.bind(&qh, 1..=1, ()).unwrap();
-    let session_lock_manager: ext_session_lock_manager_v1::ExtSessionLockManagerV1 = globals.bind(&qh, 1..=1, ()).map_err(|_| {
-        "Could not bind ext-session-lock-v1. Your compositor probably does not support this."
-    })?;
+    let session_lock_manager: ext_session_lock_manager_v1::ExtSessionLockManagerV1 =
+        globals.bind(&qh, 1..=1, ()).map_err(|_| {
+            "Could not bind ext-session-lock-v1. Your compositor probably does not support this."
+        })?;
     let session_lock = session_lock_manager.lock(&qh, ());
     // set surface role as session lock surface
     session_lock.get_lock_surface(&wl_surface, &output, &qh, ());
@@ -123,16 +126,19 @@ pub fn windowing_thread(
 
                 continue 'event_loop;
             }
-            Err(RecvTimeoutError::Timeout) => {
-                event_queue.blocking_dispatch(&mut state)?;
-
-                if !state.running {
-                    break 'event_loop;
-                }
-            }
+            Err(RecvTimeoutError::Timeout) => {}
             Err(RecvTimeoutError::Disconnected) => {
                 break 'event_loop;
             }
+        }
+
+        match event_queue.dispatch(&mut state, Some(Duration::from_millis(0))) {
+            Ok(_) | Err(DispatchError::Timeout) => {}
+            Err(err) => return Err(err.into()),
+        }
+
+        if !state.running {
+            break 'event_loop;
         }
     }
 


### PR DESCRIPTION
## Summary
- restructure the Wayland event loop to drain UI messages before blocking and to periodically poll for work
- add an AppData helper to process UiMessage variants, rendering frames immediately and flushing the queue after commits

## Testing
- cargo fmt
- cargo check *(fails: unable to download crates due to 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_68d35b80ac4c8322ae197b3c74dcae42